### PR TITLE
Made PR template to use only English

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,32 +1,27 @@
-## チケットへのリンク Link to ticket
+## Link to ticket
 
-trelloとかのチケットをリンクできれば見やすいです。
+Ticket link to Trello
 
 [Issue](https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
 
 - https://example.com
 
-## やったこと Done
+## What you did
 
-- このプルリクで何をしたのか？
 - What did you do with this pull request?
 
-## できるようになること（ユーザ目線） Be able to
+## Be able to
 
-- 何ができるようになるのか？（あれば。無いなら「無し」で OK）
 - What will you be able to do? (If there is. If there is none, "None" is OK)
 
-## できなくなること（ユーザ目線） Becoming unable to
+## Becoming unable to
 
-- 何ができなくなるのか？（あれば。無いなら「無し」で OK）
 - What will you be unable to do? (If there is. If there is none, "None" is OK)
 
-## 動作確認 Operation check
+## Operation check
 
-- どのような動作確認を行ったのか？　結果はどうか？
 - What kind of operation check was performed? "What about the results?"
 
-## その他 Others
+## Memos for Others
 
-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
 - Reference information for reviewers (include any implementation concerns or points to note)


### PR DESCRIPTION
## What you did

- Changed PR template to use only English because this repo maybe refered by hiring team in Canada in the future.